### PR TITLE
:pencil: Build project before testing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 1. clone repository
 2. Run `npm install`
-3. Run `npm run frontend` to start frontend server
-4. Run `npm run examples` to start backend server with tests in `example` package
-5. Open in browser `http://localhost:8080`
+3. Run `npm build`
+4. Run `npm run frontend` to start frontend server
+5. Run `npm run examples` to start backend server with tests in `example` package
+6. Open in browser `http://localhost:8080`
 
 ## Making Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Execute it:
 npx codecept-ui
 ```
 
+# ENV
+
+* port: Update default port of websocket (3000) and Codecept UI (defaultPort + 1)
+
 ## Development Mode
 
 See [CONTRIBUTING.md](https://github.com/codecept-js/ui/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
Hi !

Is necessary to build project to test app.

Because `bin/codecept-ui.js` use `/dist` with express

I have updated contributing readme.