### PR TITLE
UUID reference fixed

### DIFF
--- a/lib/codeceptjs/console-recorder.helper.js
+++ b/lib/codeceptjs/console-recorder.helper.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('codepress:console-recorder-helper');
 const wsEvents = require('../model/ws-events');
-const uuid = require('uuid/v4');
+const uuid = require('uuid');
 // eslint-disable-next-line no-undef
 let Helper = codecept_helper;
 

--- a/lib/codeceptjs/console-recorder.helper.js
+++ b/lib/codeceptjs/console-recorder.helper.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('codepress:console-recorder-helper');
 const wsEvents = require('../model/ws-events');
-const uuid = require('uuid');
+const { v4: uuid } = require('uuid');
 // eslint-disable-next-line no-undef
 let Helper = codecept_helper;
 


### PR DESCRIPTION
The syntax that is used here for referencing the uuid package is deprecated.
https://stackoverflow.com/questions/62549457/error-err-package-path-not-exported-package-subpath-v4-is-not-defined-by

I was not able to run a clean install of the codeceptjs/ui and received the same error message like codeceptjs/ui#91. Including the new reference and removing the deprecated was required to get codeceptjs/ui up and running again.