### PR TITLE
fix: realtime reporter only set id on non null step.metaStep

### DIFF
--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -263,8 +263,8 @@ class RealtimeReporterHelper extends Helper {
     if (!isEqualMetaStep(this.step.metaStep, this.metaStep)) {      
       // append changed metastep to list 
       // NOTE this.metaStep can be null which means "no metastep"
-      this.step.metaStep.id = nanoid();
       if (this.step.metaStep) {
+        this.step.metaStep.id = nanoid();
         wsEvents.rtr.metaStepChanged(this._mapMetaStep(this.step.metaStep, true));
       }
       this.metaStep = this.step.metaStep;


### PR DESCRIPTION
Launching test with the latest version of the codecept ui always terminated with an error setting an id on a null metaStep object.
Digging in the source code revealed that an id is generated and assigned to metaStep before checking that it's not null.

Here is a quick fix