### PR TITLE
Adding license information to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codeceptjs/ui",
   "version": "0.4.3",
+  "license": "MIT",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",


### PR DESCRIPTION
Tools like VersionEye are using this information for license compliance analysis.