### PR TITLE
Fixes `testStartedAt` issue in electron when using `beforeSuite`

### DIFF
--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -238,7 +238,7 @@ class RealtimeReporterHelper extends Helper {
 
     return {
       id: step.id,
-      testId: this.test.id,
+      testId: this.test && this.test.id || this.suite && this.suite.id,
       at: Date.now() - testStartedAt,
       startedAt: step.startTime,
       duration: Date.now() - step.startTime,
@@ -294,7 +294,8 @@ class RealtimeReporterHelper extends Helper {
 
   async _beforeSuite(suite) {  
     if (!this._isEnabled()) return;
-    this.suite = suite; 
+    this.suite = suite;
+    this.testStartedAt = Date.now();
    
     wsEvents.rtr.suiteBefore(mapSuiteAndTest(Date.now(), this.suite, this.test));
   }


### PR DESCRIPTION
# Problem

I am trying to use a helper in our `BeforeSuite`, however, when I  run the tests in UI, I am getting an error named `testStartedAt`. Below is the error for the same.

<img width="1513" alt="Screenshot 2021-05-28 at 12 42 25 PM" src="https://user-images.githubusercontent.com/16587779/119944671-2b82ac00-bfb2-11eb-9525-483f21d0c7e9.png">


#### Some observations
- The same test is passing when i run the codecept without electron
- When I run the same test by replacing the `BeforeSuite` with `Before` it works in ui mode also

#### What do you get instead?

```bash
 "before all" hook: BeforeSuite for "Homepage":
     testStartedAt is required
      at RealtimeReporterHelper._mapStep (node_modules/@codeceptjs/ui/lib/codeceptjs/realtime-reporter.helper.js:209:5)
      at /Users/anirudhmodi/Documents/hackit/codecept-demo/node_modules/@codeceptjs/ui/lib/codeceptjs/realtime-reporter.helper.js:137:16

```


```js
// example_test.js
Feature('Github homepage');

BeforeSuite(async ({ I }) => {

    // Will wait for 3000ms and then load
    await I.performSetup(3000);
    I.amOnPage('https://github.com/codeceptjs/ui');
});

Scenario('Homepage', ({ I }) => {
    I.grabAttributeFrom('.author');
});
```

```js
// PageHelper.js

const Helper = require('@codeceptjs/helper');

class PageHelper extends Helper {
    performSetup(n) {
        return new Promise((resolve, reject) => {
            setTimeout(() => {
                resolve();
            },n);
        });
    }
}
module.exports = PageHelper;

```

#### Sample repo for the problem
The problem can be replicated by running the `npm run codeceptjs:ui` in this repo.
https://github.com/anirudh-modi/codecept-demo

# Solution
After looking at the code I found that for the function `_mapSteps`, `testStartedAt` is a required param.
https://github.com/codeceptjs/ui/blob/2bddb06ec8cb5de546027da0f931c297ddc96e4c/lib/codeceptjs/realtime-reporter.helper.js#L209


`this.testStartedAt` is only initialized during `_before` function present in the file `realtime-reporter.helper.js`. Below is the code

https://github.com/codeceptjs/ui/blob/2bddb06ec8cb5de546027da0f931c297ddc96e4c/lib/codeceptjs/realtime-reporter.helper.js#L302
```js
async _before(t) {
    if (!this._isEnabled(t)) return;

    t.retries(0); // disable retries in web ui
    this.test = t;
    this.testStartedAt = Date.now();
    this.step = undefined;
    this.metaStep = undefined;
    this.loggedMetaSteps = [];
    this.cachedStackFrameInTest = undefined;

    wsEvents.rtr.testBefore(mapSuiteAndTest(this.testStartedAt, this.suite, this.test));
  }
```


However for the `_beforeSuite` it is not initialized

https://github.com/codeceptjs/ui/blob/2bddb06ec8cb5de546027da0f931c297ddc96e4c/lib/codeceptjs/realtime-reporter.helper.js#L295
```js
async _beforeSuite(suite) {  
    if (!this._isEnabled()) return;
    this.suite = suite; 

    wsEvents.rtr.suiteBefore(mapSuiteAndTest(Date.now(), this.suite, this.test));
  }
```


Simply, declaring `this.testStartedAt` in `_beforeSuite` was not sufficient, as, `_mapSteps` is dependent on the `this.test.id` which remains `undefined` as during the _beforeSuite `this.test` is not initialized.


https://github.com/codeceptjs/ui/blob/2bddb06ec8cb5de546027da0f931c297ddc96e4c/lib/codeceptjs/realtime-reporter.helper.js#L241
```js
return {
      id: step.id,
      testId: this.test.id,
      at: Date.now() - testStartedAt,
      startedAt: step.startTime,
      duration: Date.now() - step.startTime,
      actor: 'I',
      humanized: step.humanize(),
      humanizedArgs: step.humanizeArgs(),
      status: step.status,
      name: step.name,
      args: mapArgs(step.args),
      store: Object.assign({}, store),
      snapshot,
      logs: step.logs || [],
      section: this._generateSection(step.metaStep),
      metaStep: this._mapMetaStep(step.metaStep),
      returnValue: step.returnValue,
      command: step.command,
      stack
    };
```