### PR TITLE
Update fix-html-snapshot.js

### DIFF
--- a/lib/model/snapshot-store/fix-html-snapshot.js
+++ b/lib/model/snapshot-store/fix-html-snapshot.js
@@ -54,6 +54,7 @@ const mapAttr = ($, snapshot, attrName) => {
 
 module.exports = snapshot => {
   // disable script tags
+  snapshot.source = snapshot.source || '';
   let $ = cheerio.load(snapshot.source.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ''));
 
   // Convert links


### PR DESCRIPTION
When test fails it always gets snapshot.source as undefined, leading to displaying this error of replace is not defined in undefined rather then showing initial cause of error in failed test. probably we need to make sure snapshot always have source, even empty one returned when it's created, but it's easier fix, considering i'm not aware of whole codebase yet.
I used playwright with chromium, strange thing but in `lib/codeceptjs/reporter-utils.js` in `takeSnapshot` snapshot doesn't have `source` set, so my proposed change probably should be better done within  this function, setting at least empty string as value to `source`.