### PR TITLE
Fetch protocol from browser

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,11 +21,11 @@ const store = require('./store').default;
 
 
 (async () => {
-  const response = await axios.get(`http://${window.location.hostname}:${window.location.port}/api/ports`);
+  const response = await axios.get(`${window.location.protocol}//${window.location.hostname}:${window.location.port}/api/ports`);
   const data = await response.data;
   Vue.use(new VueSocketIO({
     debug: true,
-    connection: `http://${window.location.hostname}:${data.wsPort}`,
+    connection: `${window.location.protocol}//${window.location.hostname}:${data.wsPort}`,
     vuex: {
       store,
       actionPrefix: 'SOCKET_',


### PR DESCRIPTION
Updating to fetch the protocol from the browser rather than a hardcoded `http`

When I tried to deploy the UI out to the k8 instance over https, the API calls to ports were error out as the browser would not allow redirecting HTTPS traffic over to HTTP. 

Fetching the protocol from the browser helps avert that situation.

I think this might resolve the following issue as well #125 