### PR TITLE
Replace references to codepress with codeceptjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An interactive, graphical test runner for [CodeceptJS](https://codecept.io). 
 
 
-![codeceptui](https://github.com/codeceptjs/ui/raw/master/codecept-ui2.gif)
+![codeceptui](codecept-ui2.gif)
 
 * Runs as Electron app or as a web server
 * Headless & window mode supported
@@ -44,7 +44,7 @@ npx codecept run --config tests/codecept.conf.js
 
 ### WebServer Mode
 
-![](https://github.com/codeceptjs/ui/raw/master/codeceptui.gif)
+![webserver mode](codeceptui.gif)
 
 Run CodeceptUI as a web server (recommended for headless mode, remote debug):
 
@@ -85,19 +85,19 @@ npx codecept-ui --app --wsPort=4444
 
 ## Development
 
-See [CONTRIBUTING.md](https://github.com/codeceptjs/ui/blob/master/.github/CONTRIBUTING.md)
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 
 
 ## Start CodeceptUI with debug output
 
-codepress uses the debug package to output debug information. This is useful to troubleshoot problems or just to see what codepress is doing. To turn on debug information do
+CodeceptUI uses the [debug](https://github.com/debug-js/debug) package to output debug information. This is useful to troubleshoot problems or just to see what CodeceptUI is doing. To turn on debug information do
 
 ```
   # verbose: get all debug information
-  DEBUG=codepress:* npx codecept-ui 
+  DEBUG=codeceptjs:* npx codecept-ui 
 
   # just get debug output of one module
-  DEBUG=codepress:codeceptjs-factory npx codecept-ui
+  DEBUG=codeceptjs:codeceptjs-factory npx codecept-ui
 ```
 
 # Credits
@@ -120,5 +120,6 @@ Thanks all for the contributions!
 <a href="https://github.com/kaflan"><img src="https://avatars3.githubusercontent.com/u/3959504?v=4" title="kaflan" width="80" height="80"></a>
 <a href="https://github.com/lukasf98"><img src="https://avatars2.githubusercontent.com/u/22434650?v=4" title="lukasf98" width="80" height="80"></a>
 <a href="https://github.com/geilix10"><img src="https://avatars3.githubusercontent.com/u/16301998?v=4" title="geilix10" width="80" height="80"></a>
+<a href="https://github.com/Teomik129"><img src="https://avatars3.githubusercontent.com/u/23395221?v=4" title="Teomik129" width="80" height="80"></a>
 
 [//]: contributor-faces

--- a/bin/codecept-ui.js
+++ b/bin/codecept-ui.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const debug = require('debug')('codepress:codepress');
+const debug = require('debug')('codeceptjs:ui');
 
 // initialize CodeceptJS and return startup options
 const path = require('path');

--- a/lib/api/get-config.js
+++ b/lib/api/get-config.js
@@ -1,7 +1,7 @@
 const codeceptjsFactory = require('../model/codeceptjs-factory');
 
 module.exports = (req, res) => {
-  const internalHelpers = Object.keys(codeceptjsFactory.codepressHelpersConfig.helpers);
+  const internalHelpers = Object.keys(codeceptjsFactory.codeceptjsHelpersConfig.helpers);
   const { config, container } = codeceptjsFactory.getInstance();
   const helpers = Object.keys(container.helpers()).filter(helper => internalHelpers.indexOf(helper) < 0);
 

--- a/lib/api/get-scenario-status.js
+++ b/lib/api/get-scenario-status.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:get-scenario-status');
+const debug = require('debug')('codeceptjs:get-scenario-status');
 const scenarioStatusRepository = require('../model/scenario-status-repository');
 
 module.exports = (req, res) => {

--- a/lib/api/get-snapshot-html.js
+++ b/lib/api/get-snapshot-html.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:get-snapshot-html');
+const debug = require('debug')('codeceptjs:get-snapshot-html');
 const snapshotStore = require('../model/snapshot-store');
 
 module.exports = (req, res) => {

--- a/lib/api/get-snapshot-image.js
+++ b/lib/api/get-snapshot-image.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:get-snapshot-image');
+const debug = require('debug')('codeceptjs:get-snapshot-image');
 const snapshotStore = require('../model/snapshot-store');
 const fs = require('fs');
 const path = require('path');

--- a/lib/api/list-actions.js
+++ b/lib/api/list-actions.js
@@ -1,7 +1,7 @@
 function _interopDefault(ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex.default : ex; }
 const acorn = require('acorn');
 const parser = _interopDefault(require('parse-function'))({ parse: acorn.parse, ecmaVersion: 11 });
-const debug = require('debug')('codepress:codeceptjs-factory');
+const debug = require('debug')('codeceptjs:codeceptjs-factory');
 const fs = require('fs');
 const path = require('path');
 const codeceptjsFactory = require('../model/codeceptjs-factory');

--- a/lib/api/new-test.js
+++ b/lib/api/new-test.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:run-scenario');
+const debug = require('debug')('codeceptjs:run-scenario');
 const wsEvents = require('../model/ws-events');
 const pause = require('../codeceptjs/brk');
 const { event } = require('codeceptjs');

--- a/lib/api/run-scenario-parallel.js
+++ b/lib/api/run-scenario-parallel.js
@@ -1,5 +1,5 @@
 const os = require('os');
-const debug = require('debug')('codepress:run-scenario-multiple');
+const debug = require('debug')('codeceptjs:run-scenario-multiple');
 const wsEvents = require('../model/ws-events');
 const { event } = require('codeceptjs');
 const codeceptjsFactory = require('../model/codeceptjs-factory');

--- a/lib/api/run-scenario.js
+++ b/lib/api/run-scenario.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:run-scenario');
+const debug = require('debug')('codeceptjs:run-scenario');
 const wsEvents = require('../model/ws-events');
 const { event } = require('codeceptjs');
 const codeceptjsFactory = require('../model/codeceptjs-factory');

--- a/lib/api/stop.js
+++ b/lib/api/stop.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:run-scenario');
+const debug = require('debug')('codeceptjs:run-scenario');
 const { event } = require('codeceptjs');
 
 module.exports = async (req, res) => {

--- a/lib/codeceptjs/console-recorder.helper.js
+++ b/lib/codeceptjs/console-recorder.helper.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:console-recorder-helper');
+const debug = require('debug')('codeceptjs:console-recorder-helper');
 const wsEvents = require('../model/ws-events');
 const { v4: uuid } = require('uuid');
 // eslint-disable-next-line no-undef

--- a/lib/codeceptjs/network-recorder.helper.js
+++ b/lib/codeceptjs/network-recorder.helper.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:network-helper');
+const debug = require('debug')('codeceptjs:network-helper');
 const wsEvents = require('../model/ws-events');
 
 // eslint-disable-next-line no-undef

--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:realtime-reporter-helper');
+const debug = require('debug')('codeceptjs:realtime-reporter-helper');
 const assert = require('assert');
 const { nanoid } = require('nanoid');
 const scenarioStatusRepository = require('../model/scenario-status-repository');

--- a/lib/codeceptjs/reporter-utils.js
+++ b/lib/codeceptjs/reporter-utils.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:reporter-utils');
+const debug = require('debug')('codeceptjs:reporter-utils');
 const assert = require('assert');
 const crypto = require('crypto');
 

--- a/lib/model/codeceptjs-factory.js
+++ b/lib/model/codeceptjs-factory.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:codeceptjs-factory');
+const debug = require('debug')('codeceptjs:codeceptjs-factory');
 const path = require('path');
 const { codecept: Codecept, container, config } = require('codeceptjs');
 
@@ -15,7 +15,7 @@ module.exports = new class CodeceptjsFactory {
     this.configFile = configFile;
   }
 
-  loadCodepressHelpers() {
+  loadCodeceptJSHelpers() {
     debug('Loading helpers...');
     const RealtimeReporterHelper = require('../codeceptjs/realtime-reporter.helper');
     const NetworkRecorderHelper = require('../codeceptjs/network-recorder.helper');
@@ -86,8 +86,8 @@ module.exports = new class CodeceptjsFactory {
     // create helpers, support files, mocha
     container.create(cfg, opts);
 
-    this.codepressHelpersConfig = this.loadCodepressHelpers(container);
-    container.append(this.codepressHelpersConfig);
+    this.codeceptjsHelpersConfig = this.loadCodeceptJSHelpers(container);
+    container.append(this.codeceptjsHelpersConfig);
 
     debug('Running hooks...');
     codecept.runHooks();

--- a/lib/model/open-in-editor.js
+++ b/lib/model/open-in-editor.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:open-in-editor');
+const debug = require('debug')('codeceptjs:open-in-editor');
 const { execSync } = require('child_process');
 const { getSettings } = require('./settings-repository');
 

--- a/lib/model/profile-repository.js
+++ b/lib/model/profile-repository.js
@@ -1,9 +1,9 @@
-const debug = require('debug')('codepress:profile-repository');
+const debug = require('debug')('codeceptjs:profile-repository');
 const fs = require('fs');
 const path = require('path');
 
-const CodepressDir = path.join(process.cwd(), '.codepress');
-const ProfileConfigFile = path.join(CodepressDir, 'profile.conf.js');
+const CodeceptJSDir = path.join(process.cwd(), '.codeceptjs');
+const ProfileConfigFile = path.join(CodeceptJSDir, 'profile.conf.js');
 
 const getProfiles = () => {
   if (!fs.existsSync(ProfileConfigFile)) return;

--- a/lib/model/scenario-repository.js
+++ b/lib/model/scenario-repository.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:scenario-repository');
+const debug = require('debug')('codeceptjs:scenario-repository');
 const fs = require('fs');
 const path = require('path');
 const chokidar = require('chokidar');

--- a/lib/model/scenario-status-repository.js
+++ b/lib/model/scenario-status-repository.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const debug = require('debug')('codepress:scenario-status-repository');
+const debug = require('debug')('codeceptjs:scenario-status-repository');
 const fs = require('fs');
 const path = require('path');
 const mkdir = require('../utils/mkdir');

--- a/lib/model/settings-repository.js
+++ b/lib/model/settings-repository.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:settings-repository');
+const debug = require('debug')('codeceptjs:settings-repository');
 
 const settings = {};
 

--- a/lib/model/snapshot-store/index.js
+++ b/lib/model/snapshot-store/index.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:snapshot-store');
+const debug = require('debug')('codeceptjs:snapshot-store');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');

--- a/lib/model/testrun-repository.js
+++ b/lib/model/testrun-repository.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('codepress:testRunRepository');
+const debug = require('debug')('codeceptjs:testRunRepository');
 const fs = require('fs');
 const path = require('path');
 const mkdir = require('../utils/mkdir');

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but codepress doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but CodeceptUI doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/src/services/selector-finder.js
+++ b/src/services/selector-finder.js
@@ -61,7 +61,7 @@ export const findShortSelector = (doc, el) => {
 
 export const dehighlightAll = doc => {
   try {
-    const oldOutlines = doc.querySelectorAll('.codepress-outline');
+    const oldOutlines = doc.querySelectorAll('.codeceptjs-outline');
     oldOutlines.forEach(ol => ol.remove());
   } catch (err) {
     // eslint-disable-next-line
@@ -81,7 +81,7 @@ export const highlightElement = (el, doc, win) => {
   const highlightColor = 'hsl(348, 100%, 61%)';
 
   var newOutline = doc.createElement('div');
-  newOutline.className = 'codepress-outline';
+  newOutline.className = 'codeceptjs-outline';
   newOutline.style.position = 'absolute';
   newOutline.style['z-index'] = '9999999999';
   newOutline.style['color'] = 'white';
@@ -98,7 +98,7 @@ export const highlightElement = (el, doc, win) => {
   newOutline.style.left = rect.left + win.pageXOffset + 'px';
 
   const textContainer = doc.createElement('div');
-  textContainer.className = 'codepress-outline';
+  textContainer.className = 'codeceptjs-outline';
   textContainer.append(doc.createTextNode(shortestSelector));
   textContainer.style.position = 'absolute';
   textContainer.style['z-index'] = '9999999999';


### PR DESCRIPTION
I noticed there were still references to `codepress` that would otherwise prevent debug output. I replaced all of them with `codeceptjs` or CodeceptUI where appropriate.