### PR TITLE
fix: handle rejection promise

### DIFF
--- a/bin/codecept-ui.js
+++ b/bin/codecept-ui.js
@@ -21,7 +21,7 @@ if (!existsSync(AppDir)) {
 
 codeceptjsFactory.create({}, options).then(() => {
   debug('CodeceptJS initialized, starting application');
-  
+
   const api = require('../lib/api');
   const app = express();
 
@@ -71,8 +71,7 @@ codeceptjsFactory.create({}, options).then(() => {
     require('../lib/commands/electron');
   }
 
+}).catch((e) => {
+  console.error(e.message);
+  process.exit(1);
 });
-
-
-
-


### PR DESCRIPTION
Resolve https://github.com/codeceptjs/CodeceptJS/issues/3547
Handling the rejection promise nicely

````
tth~$npm run codeceptjs:ui

> codeceptjs-tests@0.1.0 codeceptjs:ui
> codecept-ui --app

(node:33202) UnhandledPromiseRejectionWarning: Error: Config file /Users/trung-thanh/Desktop/create-codeceptjs-fun/codecept.conf.js does not exist. Execute 'codeceptjs init' to create config
    at Function.load (/Users/trung-thanh/Desktop/create-codeceptjs-fun/node_modules/codeceptjs/lib/config.js:85:17)
    at CodeceptjsFactory.create (/Users/trung-thanh/Desktop/create-codeceptjs-fun/node_modules/@codeceptjs/ui/lib/model/codeceptjs-factory.js:73:12)
    at Object.<anonymous> (/Users/trung-thanh/Desktop/create-codeceptjs-fun/node_modules/@codeceptjs/ui/bin/codecept-ui.js:22:19)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47
(Use `node --trace-warnings ...` to show where the warning was created)
(node:33202) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:33202) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

````