### PR TITLE
perf: use Clipboard API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "buefy": "^0.9.13",
         "codeceptjs": "^3.7.3",
         "contributor-faces": "^1.1.0",
-        "copy-text-to-clipboard": "^3.2.0",
         "electron-icon-builder": "^2.0.1",
         "eslint": "^7.32.0",
         "eslint-plugin-vue": "^7.20.0",
@@ -14701,19 +14700,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/copy-text-to-clipboard": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
-      "integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/copy-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "buefy": "^0.9.13",
     "codeceptjs": "^3.7.3",
     "contributor-faces": "^1.1.0",
-    "copy-text-to-clipboard": "^3.2.0",
     "electron-icon-builder": "^2.0.1",
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^7.20.0",

--- a/src/components/Pause.vue
+++ b/src/components/Pause.vue
@@ -186,7 +186,6 @@
 
 <script>
 import Convert from 'ansi-to-html';
-import copyToClipboard from 'copy-text-to-clipboard';
 
 export default {
   name: 'Pause',
@@ -268,7 +267,7 @@ export default {
   },
   methods: {
     copy(text) {
-      copyToClipboard(text);
+      return navigator.clipboard.writeText(text);
     },
     selectedAction(actionText) {
       const actions = this.$store.getters['cli/actions'];

--- a/src/components/SnapshotSource.vue
+++ b/src/components/SnapshotSource.vue
@@ -22,7 +22,6 @@ import {
   highlightElement,
   highlightInIframe
 } from '../services/selector-finder';
-import copy from 'copy-text-to-clipboard';
 
 const throttled = (delay, fn) => {
   let lastCall = 0;
@@ -56,7 +55,7 @@ const handleIframeClick = (props, doc, window) =>
     if (!props.enabledSelection) return;
     const el = doc.elementFromPoint(e.x, e.y);
     const shortestSelector = highlightElement(el, doc, window);
-    copy(shortestSelector);
+    return navigator.clipboard.writeText(shortestSelector);
   });
 
 export default {

--- a/src/components/steps/Argument.vue
+++ b/src/components/steps/Argument.vue
@@ -14,7 +14,6 @@
 
 <script>
 // import {getSelectorString} from '../../services/selector';
-import copyToClipboard from 'copy-text-to-clipboard';
 
 export default {
   name: 'Argument',
@@ -36,8 +35,8 @@ export default {
     }
   },
   methods: {
-    copy() {
-      copyToClipboard(this.arg);
+    async copy() {
+      await navigator.clipboard.writeText(this.arg);
       this.copyText = 'Copied!';
       setTimeout(() => this.copyText = 'Copy', 3000);
     },


### PR DESCRIPTION
Removes a dependency in favor of the widely supported [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). This PR was made as part of the [e18e initiative](https://e18e.dev/).